### PR TITLE
fix: Move resource names to the matching platform.

### DIFF
--- a/enricher/api/src/main/java/io/fabric8/kit/enricher/api/Platform.java
+++ b/enricher/api/src/main/java/io/fabric8/kit/enricher/api/Platform.java
@@ -11,15 +11,15 @@ import java.util.Set;
 public enum Platform {
 
     KUBERNETES(
-        "DeploymentConfig",
-        "Project",
-        "Route"
-    ),
-
-    OPENSHIFT(
         "Deployment",
         "Namespace",
         "Ingress"
+    ),
+
+    OPENSHIFT(
+        "DeploymentConfig",
+        "Project",
+        "Route"
     );
 
     private final Set<String> unsupportedResources;


### PR DESCRIPTION
I think that the names need to be swapped.